### PR TITLE
Update build.gradle

### DIFF
--- a/netsugar-master/build.gradle
+++ b/netsugar-master/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.1.1'
     testCompile 'junit:junit:4.12'
     compile 'org.aspectj:aspectjrt:1.8.5'
+    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
 }
 
 android.libraryVariants.all { variant ->


### PR DESCRIPTION
without adding the "androidTestCompile" statement,you get these errors in ExampleInstrumentTest and the build fails:
Error:(4, 28) error: package android.support.test does not exist
Error:(5, 35) error: package android.support.test.runner does not exist
Error:(7, 17) error: package org.junit does not exist
Error:(8, 24) error: package org.junit.runner does not exist
Error:(10, 24) error: package org.junit does not exist
Error:(17, 2) error: cannot find symbol class RunWith
Error:(19, 6) error: cannot find symbol class Test
Error:(22, 30) error: cannot find symbol variable InstrumentationRegistry
Error:(24, 9) error: cannot find symbol method assertEquals(String,String)
Error:Execution failed for task ':netsugar-master:compileDebugAndroidTestJavaWithJavac'.